### PR TITLE
Propagate conversion errors in parsers

### DIFF
--- a/src/elf/program.rs
+++ b/src/elf/program.rs
@@ -30,42 +30,74 @@ impl ProgramHeader {
             }
 
             let p_type = Field::new(
-                u32::from_le_bytes(buffer[base..base + 4].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base..base + 4]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base,
                 4,
             );
             let p_flags = Field::new(
-                u32::from_le_bytes(buffer[base + 4..base + 8].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base + 4..base + 8]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 4,
                 4,
             );
             let p_offset = Field::new(
-                u64::from_le_bytes(buffer[base + 8..base + 16].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 8..base + 16]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 8,
                 8,
             );
             let p_vaddr = Field::new(
-                u64::from_le_bytes(buffer[base + 16..base + 24].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 16..base + 24]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 16,
                 8,
             );
             let p_paddr = Field::new(
-                u64::from_le_bytes(buffer[base + 24..base + 32].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 24..base + 32]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 24,
                 8,
             );
             let p_filesz = Field::new(
-                u64::from_le_bytes(buffer[base + 32..base + 40].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 32..base + 40]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 32,
                 8,
             );
             let p_memsz = Field::new(
-                u64::from_le_bytes(buffer[base + 40..base + 48].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 40..base + 48]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 40,
                 8,
             );
             let p_align = Field::new(
-                u64::from_le_bytes(buffer[base + 48..base + 56].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 48..base + 56]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 48,
                 8,
             );

--- a/src/elf/section.rs
+++ b/src/elf/section.rs
@@ -32,52 +32,92 @@ impl SectionHeader {
             }
 
             let sh_name = Field::new(
-                u32::from_le_bytes(buffer[base..base + 4].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base..base + 4]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base,
                 4,
             );
             let sh_type = Field::new(
-                u32::from_le_bytes(buffer[base + 4..base + 8].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base + 4..base + 8]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 4,
                 4,
             );
             let sh_flags = Field::new(
-                u64::from_le_bytes(buffer[base + 8..base + 16].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 8..base + 16]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 8,
                 8,
             );
             let sh_addr = Field::new(
-                u64::from_le_bytes(buffer[base + 16..base + 24].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 16..base + 24]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 16,
                 8,
             );
             let sh_offset = Field::new(
-                u64::from_le_bytes(buffer[base + 24..base + 32].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 24..base + 32]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 24,
                 8,
             );
             let sh_size = Field::new(
-                u64::from_le_bytes(buffer[base + 32..base + 40].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 32..base + 40]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 32,
                 8,
             );
             let sh_link = Field::new(
-                u32::from_le_bytes(buffer[base + 40..base + 44].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base + 40..base + 44]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 40,
                 4,
             );
             let sh_info = Field::new(
-                u32::from_le_bytes(buffer[base + 44..base + 48].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base + 44..base + 48]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 44,
                 4,
             );
             let sh_addralign = Field::new(
-                u64::from_le_bytes(buffer[base + 48..base + 56].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 48..base + 56]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 48,
                 8,
             );
             let sh_entsize = Field::new(
-                u64::from_le_bytes(buffer[base + 56..base + 64].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 56..base + 64]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 56,
                 8,
             );

--- a/src/macho/header.rs
+++ b/src/macho/header.rs
@@ -19,33 +19,77 @@ impl MachHeader {
             return Err(errors::FileParseError::BufferOverflow);
         }
 
-        let magic = Field::new(u32::from_le_bytes(buffer[0..4].try_into().unwrap()), 0, 4);
-        let cpu_type = Field::new(u32::from_le_bytes(buffer[4..8].try_into().unwrap()), 4, 4);
-        let cpu_subtype = Field::new(u32::from_le_bytes(buffer[8..12].try_into().unwrap()), 8, 4);
+        let magic = Field::new(
+            u32::from_le_bytes(
+                buffer[0..4]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
+            0,
+            4,
+        );
+        let cpu_type = Field::new(
+            u32::from_le_bytes(
+                buffer[4..8]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
+            4,
+            4,
+        );
+        let cpu_subtype = Field::new(
+            u32::from_le_bytes(
+                buffer[8..12]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
+            8,
+            4,
+        );
         let file_type = Field::new(
-            u32::from_le_bytes(buffer[12..16].try_into().unwrap()),
+            u32::from_le_bytes(
+                buffer[12..16]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             12,
             4,
         );
         let ncmds = Field::new(
-            u32::from_le_bytes(buffer[16..20].try_into().unwrap()),
+            u32::from_le_bytes(
+                buffer[16..20]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             16,
             4,
         );
         let sizeofcmds = Field::new(
-            u32::from_le_bytes(buffer[20..24].try_into().unwrap()),
+            u32::from_le_bytes(
+                buffer[20..24]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             20,
             4,
         );
         let flags = Field::new(
-            u32::from_le_bytes(buffer[24..28].try_into().unwrap()),
+            u32::from_le_bytes(
+                buffer[24..28]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             24,
             4,
         );
 
         let reserved: Option<Field<u32>> = if buffer.len() >= 32 {
             Some(Field::new(
-                u32::from_le_bytes(buffer[28..32].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[28..32]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 28,
                 4,
             ))

--- a/src/macho/load_command.rs
+++ b/src/macho/load_command.rs
@@ -25,7 +25,7 @@ impl LoadCommand {
                 u32::from_le_bytes(
                     buffer[current_offset..current_offset + 4]
                         .try_into()
-                        .unwrap(),
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
                 ),
                 current_offset,
                 4,
@@ -34,7 +34,7 @@ impl LoadCommand {
                 u32::from_le_bytes(
                     buffer[current_offset + 4..current_offset + 8]
                         .try_into()
-                        .unwrap(),
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
                 ),
                 current_offset + 4,
                 4,

--- a/src/macho/mod.rs
+++ b/src/macho/mod.rs
@@ -58,7 +58,11 @@ impl MachO {
         }
 
         let magic = match buffer.get(0..4) {
-            Some(bytes) => u32::from_le_bytes(bytes.try_into().unwrap()),
+            Some(bytes) => u32::from_le_bytes(
+                bytes
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             None => return Err(errors::FileParseError::BufferOverflow),
         };
 

--- a/src/macho/segment.rs
+++ b/src/macho/segment.rs
@@ -31,42 +31,74 @@ impl Segment {
                     .trim_end_matches('\0')
                     .to_string();
                 let vmaddr = Field::new(
-                    u64::from_le_bytes(buffer[offset + 24..offset + 32].try_into().unwrap()),
+                    u64::from_le_bytes(
+                        buffer[offset + 24..offset + 32]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 24,
                     8,
                 );
                 let vmsize = Field::new(
-                    u64::from_le_bytes(buffer[offset + 32..offset + 40].try_into().unwrap()),
+                    u64::from_le_bytes(
+                        buffer[offset + 32..offset + 40]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 32,
                     8,
                 );
                 let fileoff = Field::new(
-                    u64::from_le_bytes(buffer[offset + 40..offset + 48].try_into().unwrap()),
+                    u64::from_le_bytes(
+                        buffer[offset + 40..offset + 48]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 40,
                     8,
                 );
                 let filesize = Field::new(
-                    u64::from_le_bytes(buffer[offset + 48..offset + 56].try_into().unwrap()),
+                    u64::from_le_bytes(
+                        buffer[offset + 48..offset + 56]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 48,
                     8,
                 );
                 let maxprot = Field::new(
-                    u32::from_le_bytes(buffer[offset + 56..offset + 60].try_into().unwrap()),
+                    u32::from_le_bytes(
+                        buffer[offset + 56..offset + 60]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 56,
                     4,
                 );
                 let initprot = Field::new(
-                    u32::from_le_bytes(buffer[offset + 60..offset + 64].try_into().unwrap()),
+                    u32::from_le_bytes(
+                        buffer[offset + 60..offset + 64]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 60,
                     4,
                 );
                 let nsects = Field::new(
-                    u32::from_le_bytes(buffer[offset + 64..offset + 68].try_into().unwrap()),
+                    u32::from_le_bytes(
+                        buffer[offset + 64..offset + 68]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 64,
                     4,
                 );
                 let flags = Field::new(
-                    u32::from_le_bytes(buffer[offset + 68..offset + 72].try_into().unwrap()),
+                    u32::from_le_bytes(
+                        buffer[offset + 68..offset + 72]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 68,
                     4,
                 );


### PR DESCRIPTION
## Summary
- Avoid panic in ELF program and section header parsing by mapping byte conversion errors to `FileParseError::BufferOverflow`
- Do the same for Mach-O header, load command, segment and file parsing

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688de17b6f9083209fe5d7d1458a0c6d